### PR TITLE
Remove Synth dependency

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,0 +1,2 @@
+^.*\.Rproj$
+^\.Rproj\.user$

--- a/R/funky_synth.R
+++ b/R/funky_synth.R
@@ -1,9 +1,28 @@
-#` Functional Key Synthetic Control
-#`
+#' Functional Key Synthetic Control
+#'
+#' TODO documentation
+#' @param y outcome
+#' @param t time
+#' @param unit unit
+#' @param intervention indicator for intervention
+#' @param treated indicator for treated
+#' @param data name of data object
+#' @return funkySynth object
+#' 
+#' @details TODO
+#'
+#' @example 
+#' TODO Example code  
+#'
 #' @importFrom fdapace FPCA
-#' @importFrom Synth synth
 
-funkySynth = function(y, t, unit, intervention, treated, ...){
+funkySynth = function(y, t, unit, intervention, treated, data, ...){
+  #TODO Data checks
+  #TODO Make data argument work as intended
+  #TODO Formula input either as an option or instead of y, t, unit, 
+  #       intervention, treated arguments
+  #TODO best way to input covariates as an argument?
+  
   treatedID = which(unique(unit) %in% unique(unit[treated]))
   interventionTime = sum(intervention == FALSE) / length(unique(unit))
   minTime = min(t)
@@ -20,14 +39,13 @@ funkySynth = function(y, t, unit, intervention, treated, ...){
   lambdaPre = fpcaPre$lambda
   fpcaDatPre = phiPre %*% t(xiPre) + muPre
   
+  #TODO create appropriate matricies with covariates
   X1 = matrix(t(xiPre)[, treatedID], ncol = 1)
   X0 = t(xiPre)[, -treatedID]
-  Z1 = matrix(fpcaDatPre[, treatedID], ncol = 1)
-  Z0 = fpcaDatPre[, -treatedID]
   V = lambdaPre / sum(lambdaPre)
   
-  synthFit = synth(X1 = X1, X0 = X0, Z1 = Z1, Z0 = Z0, custom.v = V)
-  w = synthFit$solution.w
+  #TODO add additional arguments for optimization (maybe using ...?)
+  w = solveForWeights(X0, X1, V)
   
   fpcaPost = FPCA(listDat$ylistPost, listDat$tlistPost, fpcaOptions)
   xiPost = fpcaPost$xiEst
@@ -35,16 +53,17 @@ funkySynth = function(y, t, unit, intervention, treated, ...){
   muPost = fpcaPost$mu
   fpcaDatPost = phiPost %*% t(xiPost) + muPost
   synthControl = fpcaDatPost[, -treatedID] %*% w
-  # RMSPEpre = sqrt(mean((fpcaDatPost[minTime:(interventionTime - 1), treatedID] - 
+  # RMSEpre = sqrt(mean((fpcaDatPost[minTime:(interventionTime - 1), treatedID] - 
   #                         synthControl[minTime:(interventionTime - 1)])^2))
-  # RMSPEpost = sqrt(mean((fpcaDatPost[interventionTime:maxTime, treatedID] - 
+  # RMSEpost = sqrt(mean((fpcaDatPost[interventionTime:maxTime, treatedID] - 
   #                          synthControl[interventionTime:maxTime])^2))
   # ATE = mean(fpcaDatPost[interventionTime:maxTime, treatedID] -
   #              synthControl[interventionTime:maxTime])
   ATE = mean(fpcaDatPost[, treatedID] -
                synthControl)
-  return(list(#RMSPEpre = RMSPEpre, RMSPEpost = RMSPEpost, 
+  #TODO create funkySynth class, also figure out what stats we should return
+  
+  return(list(#RMSEpre = RMSEpre, RMSEpost = RMSEpost, 
     ATE = ATE, w = w, 
-    sytheticControl = synthControl, functionalData = fpcaDatPost,
-    loss = synthFit$loss.w))
+    sytheticControl = synthControl, functionalData = fpcaDatPost))
 }

--- a/R/lintify_data.R
+++ b/R/lintify_data.R
@@ -1,4 +1,4 @@
-#` Function subsets data to a single list unit (lint)
+#' Function subsets data to a single list unit or "lint".
 
 lintifyData = function(u, y, t, ut, it, prepost, yt){
   if(prepost == "pre"){

--- a/R/listify_data.R
+++ b/R/listify_data.R
@@ -1,4 +1,4 @@
-#` Converts data frame into list format needed for funkySynth()
+#' Converts data frame into list format needed for funkySynth()
 
 listifyData = function(y, t, ut, it){
   ylistPre = lapply(unique(ut), lintifyData, y = y, t = t, ut = ut,

--- a/R/solve_for_weights.R
+++ b/R/solve_for_weights.R
@@ -1,0 +1,24 @@
+#' Find SCM weights using quadratic optimization
+#'
+#' @importFrom kernlab ipop
+#' 
+#'  
+
+solveForWeights = function(X0, X1, V, Margin.ipop = 5e-04, Sigf.ipop = 5,
+                           Bound.ipop = 10){
+  X0.scaled = scale(X0)
+  X1.scaled = scale(X1)
+  V <- diag(V)
+  H <- t(X0.scaled) %*% V %*% (X0.scaled)
+  c <- -1 * c(t(X1.scaled) %*% V %*% (X0.scaled))
+  A <- t(rep(1, length(c)))
+  b <- 1
+  l <- rep(0, length(c))
+  u <- rep(1, length(c))
+  r <- 0
+  
+  res <- ipop(c = c, H = H, A = A, b = b, l = l, u = u, 
+              r = r, margin = Margin.ipop, maxiter = 1000, sigf = Sigf.ipop, 
+              bound = Bound.ipop)
+  solution.w <- as.matrix(primal(res))
+}


### PR DESCRIPTION
Removes usage of synth() function to obtain synthetic control weights.  Instead we use ipop() (which synth uses to solve for weights) directly.